### PR TITLE
correct staticlibs path

### DIFF
--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -18,7 +18,7 @@ endif
 
 CFLAGS += -Wall -m64 -std=c++11
 
-STATICLIBS = /usr/local/lib/libz.a
+STATICLIBS = /usr/lib/x86_64-linux-gnu/libz.a
 
 LIBS = -lm -lz
 


### PR DESCRIPTION
the static lib path for libz.a has changed in recent versions
see https://packages.ubuntu.com/eoan/amd64/zlib1g-dev/filelist